### PR TITLE
Fix/running fat jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,15 @@ https://github.com/nismod/smif
     * Make sure the Java home environment variable is set for the operating system and pointing to the directory where *Java Development Kit* has been installed.
     * Download maven, install it and set the environment variables: http://maven.apache.org/. Then type:  
        `mvn clean install`
-    * To run the base-year model (2015) type:  
-       `java -cp target/transport-0.0.1-SNAPSHOT-main-jar-with-dependencies.jar nismod.transport.App -c ./path/to/config.properties -b`
-    * To predict and run a future year (e.g. 2020) using the results of a previously run year (e.g. 2015) type:  
-       `java -cp target/transport-0.0.1-SNAPSHOT-main-jar-with-dependencies.jar nismod.transport.App -c ./path/to/config.properties -r 2020 2015`
+    * To run the base-year model (2015) type:
+       `java -cp target/transport-0.0.1-SNAPSHOT.jar nismod.transport.App -c ./path/to/config.properties -b`
+    * To predict and run a future year (e.g. 2020) using the results of a previously run year (e.g. 2015) type:
+       `java -cp target/transport-0.0.1-SNAPSHOT.jar nismod.transport.App -c ./path/to/config.properties -r 2020 2015`
+
+    * Options:
+
+        * To increase the max heap size, run with `java -XX:MaxHeapSize=120g ...`
+        * To enable debug messages, run with `java -Dlog4j2.debug ...`
 
 
 ## Showcase demo
@@ -66,8 +71,8 @@ The model provides an interactive showcase demo with three policy interventions 
 * *Road development* - building new road links between two existing intersections.
 * *Congestion charging* - time-based (peak and off-peak) congestion charging in the policy area.
 
-To run the showcase demo type:  
-    `java -cp target/transport-0.0.1-SNAPSHOT-main-jar-with-dependencies.jar nismod.transport.App -c ./path/to/config.properties -d`
+To run the showcase demo type:
+    `java -cp target/transport-0.0.1-SNAPSHOT.jar nismod.transport.App -c ./path/to/config.properties -d`
 
 [<img alt="Landing GUI" src="images/LandingGUI.png" style="max-width:500px"/>](images/LandingGUI.png)
 

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -168,26 +168,30 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			<!-- See http://docs.geotools.org/latest/userguide/faq.html#how-do-i-create-an-executable-jar-for-my-geotools-app -->
 			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.3</version>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<archive>
-						<manifest>
-							<mainClass>nismod.transport.App</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>1.3.1</version>
 				<executions>
 					<execution>
-						<id>make-assembly</id>
 						<phase>package</phase>
 						<goals>
-							<goal>single</goal>
+							<goal>shade</goal>
 						</goals>
+						<configuration>
+							<transformers>
+								<!-- This bit sets the main class for the executable jar as you otherwise -->
+								<!-- would with the assembly plugin -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>nismod.transport.App</Main-Class>
+									</manifestEntries>
+								</transformer>
+								<!-- This bit merges the various GeoTools META-INF/services files -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+							</transformers>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/transport/src/main/java/nismod/transport/App.java
+++ b/transport/src/main/java/nismod/transport/App.java
@@ -673,6 +673,8 @@ public class App {
 			LOGGER.error(e);
 		} catch (Exception e) {
 			LOGGER.error(ExceptionUtils.getStackTrace(e));
+		} catch (Error e) {
+			LOGGER.error(ExceptionUtils.getStackTrace(e));
 		} finally {
 			LOGGER.info("Program ended unsuccessfully.");
 			System.exit(1);


### PR DESCRIPTION
Small fixes from running v2.0.0-alpha-5:
- Fix `org.opengis.referencing.NoSuchAuthorityCodeException: No code "EPSG:27700" from authority "EPSG" found for object of type "EngineeringCRS"` - raised when running from fat jar, following the [GeoTools FAQ](http://docs.geotools.org/latest/userguide/faq.html#how-do-i-create-an-executable-jar-for-my-geotools-app)
- Catch error and print stack trace, to give more information in case of e.g. OutOfMemoryError
- Add notes on CLI options to README 