### PR TITLE
Update pom.xml to use new osgeo repo

### DIFF
--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -152,7 +152,7 @@
 		</repository>
 		<repository>
 			<id>osgeod</id>
-			<name>OSGeo Release Repository Deps</name>
+			<name>OSGeo Release Repository Dependencies</name>
 			<url>https://repo.osgeo.org/repository/release/</url>
 			<snapshots><enabled>false</enabled></snapshots>
 			<releases><enabled>true</enabled></releases>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -142,17 +142,27 @@
 			<url>http://download.java.net/maven/2</url>
 		</repository>
 		<repository>
-			<id>osgeo</id>
-			<name>Open Source Geospatial Foundation Repository</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
+			<id>central</id>
+			<name>Maven Repository Switchboard</name>
+			<layout>default</layout>
+			<url>https://repo1.maven.org/maven2</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 		<repository>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>boundless</id>
-			<name>Boundless Maven Repository</name>
-			<url>http://repo.boundlessgeo.com/main</url>
+			<id>osgeod</id>
+			<name>OSGeo Release Repository Deps</name>
+			<url>https://repo.osgeo.org/repository/release/</url>
+			<snapshots><enabled>false</enabled></snapshots>
+			<releases><enabled>true</enabled></releases>
+		</repository>
+		<repository>
+			<id>osgeo</id>
+			<name>OSGeo Release Repository</name>
+			<url>https://repo.osgeo.org/repository/Geoserver-releases/</url>
+			<snapshots><enabled>false</enabled></snapshots>
+			<releases><enabled>true</enabled></releases>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
repo.boundlessgeo.com/main is no longer available which breaks building the transport model.

There is a new repository for the OSGeo versions currently used by this model listed here https://wiki.osgeo.org/wiki/SAC:Repo this still didn't seem to be working because the maven central repository has changed as well so I updated that. I also had to add the repository for the dependencies needed by the OSGeo packages like JGridShift, with these changes I can now build the model again via Docker.