### PR TITLE
Fix apache logging and maven shade versions

### DIFF
--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.13.2</version>
+			<version>2.11.0</version>
 		</dependency>
 		<dependency>
     		<groupId>net.sf.trove4j</groupId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -182,7 +182,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>1.3.1</version>
+				<version>2.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
These versions of these 2 dependencies was preventing the transport model from being built, with these versions the build now succeeds.